### PR TITLE
Add IL2CPP compiler options

### DIFF
--- a/Editor/Data/Preset.cs
+++ b/Editor/Data/Preset.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEditor;
+using UnityEditor.Build;
 using UnityEngine;
 
 namespace Elevator89.BuildPresetter.Data
@@ -61,6 +62,12 @@ namespace Elevator89.BuildPresetter.Data
 
 		[SerializeField]
 		public bool UseIncrementalGC;
+
+		[SerializeField]
+		public Il2CppCompilerConfiguration Il2CppCompilerConfiguration;
+
+		[SerializeField]
+		public Il2CppCodeGeneration Il2CppCodeGeneration;
 	}
 }
 

--- a/Editor/PresetListWindow.cs
+++ b/Editor/PresetListWindow.cs
@@ -5,6 +5,7 @@ using UnityEditor;
 using UnityEngine;
 using Elevator89.BuildPresetter.Data;
 using Elevator89.BuildPresetter.FolderHierarchy;
+using UnityEditor.Build;
 
 namespace Elevator89.BuildPresetter
 {
@@ -268,6 +269,8 @@ namespace Elevator89.BuildPresetter
 				preset.ConnectWithProfiler = EditorGUILayout.Toggle("Connect Profiler", preset.ConnectWithProfiler);
 
 				preset.UseIncrementalGC = EditorGUILayout.Toggle("Use incremental GC", preset.UseIncrementalGC);
+				preset.Il2CppCodeGeneration = (Il2CppCodeGeneration)EditorGUILayout.EnumPopup("Il2CppCodeGeneration", preset.Il2CppCodeGeneration);
+				preset.Il2CppCompilerConfiguration = (Il2CppCompilerConfiguration)EditorGUILayout.EnumPopup("Il2CppCompilerConfiguration", preset.Il2CppCompilerConfiguration);
 
 				GUILayout.BeginHorizontal(GUILayout.ExpandHeight(false));
 				{

--- a/Editor/Presetter.cs
+++ b/Editor/Presetter.cs
@@ -4,6 +4,7 @@ using UnityEditor;
 using UnityEngine;
 using Elevator89.BuildPresetter.Data;
 using Elevator89.BuildPresetter.FolderHierarchy;
+using UnityEditor.Build;
 
 namespace Elevator89.BuildPresetter
 {
@@ -28,6 +29,7 @@ namespace Elevator89.BuildPresetter
 
 			BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
 			BuildTargetGroup buildTargetGroup = EditorUserBuildSettings.selectedBuildTargetGroup;
+			NamedBuildTarget namedBuildTarget = NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup);
 
 			preset.AppName = PlayerSettings.productName;
 			preset.AppId = PlayerSettings.applicationIdentifier;
@@ -35,7 +37,8 @@ namespace Elevator89.BuildPresetter
 			preset.BuildTargetGroup = buildTargetGroup;
 			preset.ScriptingImplementation = PlayerSettings.GetScriptingBackend(buildTargetGroup);
 			preset.IncrementalIl2CppBuild = PlayerSettings.GetIncrementalIl2CppBuild(buildTargetGroup);
-
+			preset.Il2CppCompilerConfiguration = PlayerSettings.GetIl2CppCompilerConfiguration(namedBuildTarget);
+			preset.Il2CppCodeGeneration = PlayerSettings.GetIl2CppCodeGeneration(namedBuildTarget);
 			preset.DefineSymbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
 			preset.IncludedScenes = EditorBuildSettings.scenes.Select(scene => scene.path).ToList();
 			preset.InitialSceneIndex = 0;
@@ -62,6 +65,9 @@ namespace Elevator89.BuildPresetter
 
 			PlayerSettings.SetScriptingBackend(preset.BuildTargetGroup, preset.ScriptingImplementation);
 			PlayerSettings.SetIncrementalIl2CppBuild(preset.BuildTargetGroup, preset.IncrementalIl2CppBuild);
+			PlayerSettings.SetIl2CppCompilerConfiguration(preset.BuildTargetGroup, preset.Il2CppCompilerConfiguration);
+			var namedBuildTarget = NamedBuildTarget.FromBuildTargetGroup(preset.BuildTargetGroup);
+			PlayerSettings.SetIl2CppCodeGeneration(namedBuildTarget, preset.Il2CppCodeGeneration);
 
 			PlayerSettings.SetScriptingDefineSymbolsForGroup(preset.BuildTargetGroup, preset.DefineSymbols);
 

--- a/Editor/Presetter.cs
+++ b/Editor/Presetter.cs
@@ -66,7 +66,7 @@ namespace Elevator89.BuildPresetter
 			PlayerSettings.SetScriptingBackend(preset.BuildTargetGroup, preset.ScriptingImplementation);
 			PlayerSettings.SetIncrementalIl2CppBuild(preset.BuildTargetGroup, preset.IncrementalIl2CppBuild);
 			PlayerSettings.SetIl2CppCompilerConfiguration(preset.BuildTargetGroup, preset.Il2CppCompilerConfiguration);
-			var namedBuildTarget = NamedBuildTarget.FromBuildTargetGroup(preset.BuildTargetGroup);
+			NamedBuildTarget namedBuildTarget = NamedBuildTarget.FromBuildTargetGroup(preset.BuildTargetGroup);
 			PlayerSettings.SetIl2CppCodeGeneration(namedBuildTarget, preset.Il2CppCodeGeneration);
 
 			PlayerSettings.SetScriptingDefineSymbolsForGroup(preset.BuildTargetGroup, preset.DefineSymbols);


### PR DESCRIPTION
## Problem

With a newer version of Unity, we need to change some IL2CPP compiler flags

## Solution

Add flags to UI and presets